### PR TITLE
Update to alpine version 3.8 (released 2018-06-26)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.8
 MAINTAINER Zalando SE
 
 RUN apk --no-cache upgrade && apk --no-cache add ca-certificates

--- a/README.rst
+++ b/README.rst
@@ -2,10 +2,10 @@
 Alpine Base Image
 =================
 
-This Docker base image contains Alpine Linux 3.5 and the Zalando CA certificate.
+This Docker base image contains Alpine Linux 3.8 and the Zalando CA certificate.
 Versions of this image will be immutable, i.e. there is no "latest" tag, but instead version numbers are incremented like::
 
-    <ALPINE_VERSION>-<COUNTER> (example: "3.5-1")
+    <ALPINE_VERSION>-<COUNTER> (example: "3.8-1")
 
 You can find the `latest Alpine Docker image in our open source registry`_.
 

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -3,10 +3,6 @@ pipeline:
   - id: build
     type: script
     commands:
-    - desc: 'Install required build software'
-      cmd: 'apt-get install -y make git apt-transport-https ca-certificates curl'
-    - desc: 'Install Docker'
-      cmd: 'curl -sSL https://delivery.cloud.zalando.com/utils/ensure-docker | sh'
     - desc: 'Build'
       cmd: |
         image=alpine-temp:${CDP_BUILD_VERSION}


### PR DESCRIPTION
Update to alpine version 3.8 (released 2018-06-26)

https://alpinelinux.org/posts/Alpine-3.8.0-released.html