### PR TITLE
Update to alpine 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.10
 MAINTAINER Zalando SE
 
 RUN apk --no-cache upgrade && apk --no-cache add ca-certificates


### PR DESCRIPTION
Updates to the latest alpine 3.10

Also ensures that we rebuild the image to get the new RDS CA bundle installed (current CA expires in March 2020).