### PR TITLE
update to alpine 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.11
 MAINTAINER Zalando SE
 
 RUN apk --no-cache upgrade && apk --no-cache add ca-certificates


### PR DESCRIPTION
Alpine 3.11 - this version is compatible with openjdk8 | 8.232.09-r0

https://pkgs.alpinelinux.org/packages?name=openjdk8&branch=edge&arch=x86_64 