### PR TITLE
Update alpine 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:3.11
-MAINTAINER Zalando SE
+
+LABEL maintainer="Zalando SE"
 
 RUN apk --no-cache upgrade && apk --no-cache add ca-certificates
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.12
 
 LABEL maintainer="Zalando SE"
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Alpine Base Image
 =================
 
-This Docker base image contains Alpine Linux 3.9 and the Zalando CA certificate.
+This Docker base image contains Alpine Linux 3.x and the Zalando CA certificate.
 Versions of this image will be immutable, i.e. there is no "latest" tag, but instead version numbers are incremented like::
 
     <ALPINE_VERSION>-<COUNTER> (example: "3.9-1")


### PR DESCRIPTION
* Updates to the latest alpine 3.12
* I also noticed that the Dockerfile uses the deprecated [MAINTAINER](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated) instruction and changed it to the equivalent LABEL.